### PR TITLE
Move Web Chat to master build

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <title>Web Chat: Markdown</title>
     
-    <script src="https://cdn.botframework.com/botframework-webchat/4.2.1-master.14eebbb/webchat-es5.js"></script>
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat-es5.js"></script>
     <script src="https://unpkg.com/marked@0.6.0/lib/marked.js"></script>
     <script src="https://unpkg.com/sanitize-html@1.20.0/dist/sanitize-html.min.js"></script>
     <style>


### PR DESCRIPTION
We have fixed [#1626](https://github.com/Microsoft/BotFramework-WebChat/issues/1626) in Web Chat. It will unblock your code so it no longer need to lock down on a specific version of Web Chat.

I tested in IE11.

![image](https://user-images.githubusercontent.com/1622400/51627444-eee0aa80-1ef6-11e9-949b-0319f994c629.png)
